### PR TITLE
Add keyPrefix param to read-project-properties

### DIFF
--- a/src/main/java/org/codehaus/mojo/properties/ReadPropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/properties/ReadPropertiesMojo.java
@@ -109,6 +109,18 @@ public class ReadPropertiesMojo
     private boolean quiet;
 
     /**
+     * Prefix that will be added before name of each property.
+     * Can be useful for separating properties with same name from different files.
+     */
+    @Parameter
+    private String keyPrefix = null;
+
+    public void setKeyPrefix( String keyPrefix )
+    {
+        this.keyPrefix = keyPrefix;
+    }
+
+    /**
      * Used for resolving property placeholders.
      */
     private final PropertyResolver resolver = new PropertyResolver();
@@ -178,7 +190,20 @@ public class ReadPropertiesMojo
 
             try
             {
-                project.getProperties().load( stream );
+                if ( keyPrefix != null )
+                {
+                    Properties properties = new Properties();
+                    properties.load(stream);
+                    Properties projectProperties = project.getProperties();
+                    for(String key: properties.stringPropertyNames())
+                    {
+                        projectProperties.put(keyPrefix + key, properties.get(key));
+                    }
+                }
+                else
+                {
+                    project.getProperties().load( stream );
+                }
             }
             finally
             {

--- a/src/test/java/org/codehaus/mojo/properties/ReadPropertiesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/properties/ReadPropertiesMojoTest.java
@@ -1,0 +1,109 @@
+package org.codehaus.mojo.properties;
+
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ReadPropertiesMojoTest {
+    private static final String NEW_LINE = System.getProperty("line.separator");
+
+    private MavenProject projectStub;
+    private ReadPropertiesMojo readPropertiesMojo;
+
+    @Before
+    public void setUp() {
+        projectStub = new MavenProject();
+        readPropertiesMojo = new ReadPropertiesMojo();
+        readPropertiesMojo.setProject(projectStub);
+    }
+
+
+    @Test
+    public void readPropertiesWithoutKeyprefix() throws Exception {
+        File testPropertyFile = getPropertyFileForTesting();
+        // load properties directly for comparison later
+        Properties testProperties = new Properties();
+        testProperties.load(new FileReader(testPropertyFile));
+
+        // do the work
+        readPropertiesMojo.setFiles(new File[]{testPropertyFile});
+        readPropertiesMojo.execute();
+
+        // check results
+        Properties projectProperties = projectStub.getProperties();
+        assertNotNull(projectProperties);
+        // it should not be empty
+        assertNotEquals(0, projectProperties.size());
+
+        // we are not adding prefix, so properties should be same as in file
+        assertEquals(testProperties.size(), projectProperties.size());
+        assertEquals(testProperties, projectProperties);
+
+    }
+
+    @Test
+    public void readPropertiesWithKeyprefix() throws Exception {
+        String keyPrefix = "testkey-prefix.";
+
+        File testPropertyFileWithoutPrefix = getPropertyFileForTesting();
+        Properties testPropertiesWithoutPrefix = new Properties();
+        testPropertiesWithoutPrefix.load(new FileReader(testPropertyFileWithoutPrefix));
+        // do the work
+        readPropertiesMojo.setKeyPrefix(keyPrefix);
+        readPropertiesMojo.setFiles(new File[]{testPropertyFileWithoutPrefix});
+        readPropertiesMojo.execute();
+
+        // load properties directly and add prefix for comparison later
+        Properties testPropertiesPrefix = new Properties();
+        testPropertiesPrefix.load(new FileReader(getPropertyFileForTesting(keyPrefix)));
+
+        // check results
+        Properties projectProperties = projectStub.getProperties();
+        assertNotNull(projectProperties);
+        // it should not be empty
+        assertNotEquals(0, projectProperties.size());
+
+        // we are adding prefix, so prefix properties should be same as in projectProperties
+        assertEquals(testPropertiesPrefix.size(), projectProperties.size());
+        assertEquals(testPropertiesPrefix, projectProperties);
+
+        // properties with and without prefix shouldn't be same
+        assertNotEquals(testPropertiesPrefix, testPropertiesWithoutPrefix);
+        assertNotEquals(testPropertiesWithoutPrefix, projectProperties);
+
+    }
+
+    private File getPropertyFileForTesting() throws IOException {
+        return getPropertyFileForTesting(null);
+    }
+
+    private File getPropertyFileForTesting(String keyPrefix) throws IOException {
+        File f = File.createTempFile("prop-test", ".properties");
+        f.deleteOnExit();
+        FileWriter writer = new FileWriter(f);
+        String prefix = keyPrefix;
+        if (prefix == null) {
+            prefix = "";
+        }
+        try {
+            writer.write(prefix + "test.property1=value1" + NEW_LINE);
+            writer.write(prefix + "test.property2=value2" + NEW_LINE);
+            writer.write(prefix + "test.property3=value3" + NEW_LINE);
+            writer.flush();
+        } finally {
+            writer.close();
+        }
+        return f;
+    }
+
+}


### PR DESCRIPTION
Hey guys, 

Hope that you don't mind small pull request.

Pull request is adding `keyPrefix` parameter for read-project-properties configuration. 

KeyPrefix param can be used to specify prefix value that will be added in front of each key read from specified properties. This can be useful in situations when you want to read multiple property files, with same keys but different values, under different "namespace". 

Example use case that I have stumbled on is that I have liquibase properties files for different databases and I need to load properties for them as "db1.url", "db2.url", "db1.username", "db2.username", etc. so they can be used inside configuration for different executions of maven-liquibase plugin. 

I have tested change inside my project and it is working as expected.

Hope you find it useful. 

Cheers,
Marko