### PR TITLE
Fix for #27 Unwarranted circular property definition

### DIFF
--- a/src/main/java/org/codehaus/mojo/properties/CircularDefinitionPreventer.java
+++ b/src/main/java/org/codehaus/mojo/properties/CircularDefinitionPreventer.java
@@ -52,7 +52,7 @@ class CircularDefinitionPreventer
     public CircularDefinitionPreventer visited( String key, String value )
     {
         entriesVisited.add( new VisitedProperty( key, value ) );
-        if ( keysUsed.contains( key ) )
+        if ( keysUsed.contains( key ) && !isValueResolved(value) )
         {
             circularDefinition();
         }
@@ -77,5 +77,11 @@ class CircularDefinitionPreventer
             }
         }
         throw new IllegalArgumentException( buffer.toString() );
+    }
+
+    private boolean isValueResolved(String value) {
+        int prefixPos = value.indexOf( "${" );
+        int suffixPos = value.indexOf( "}" );
+        return !(prefixPos >= 0 && suffixPos > prefixPos);
     }
 }

--- a/src/main/java/org/codehaus/mojo/properties/ExpansionBuffer.java
+++ b/src/main/java/org/codehaus/mojo/properties/ExpansionBuffer.java
@@ -52,7 +52,8 @@ class ExpansionBuffer
 
     public String toString()
     {
-        return resolved.append( unresolved ).toString();
+        StringBuilder sb = new StringBuilder(resolved);
+        return sb.append( unresolved ).toString();
     }
 
     public void add( String newKey, String newValue )

--- a/src/test/java/org/codehaus/mojo/properties/PropertyResolverTest.java
+++ b/src/test/java/org/codehaus/mojo/properties/PropertyResolverTest.java
@@ -81,6 +81,19 @@ public class PropertyResolverTest
     }
 
     @Test
+    public void propertyIncludesAnotherPropertyMoreThanOnce()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "value" );
+        properties.setProperty( "p2", "${p1} ${p1}" );
+
+        String value = resolver.getPropertyValue( "p2", properties, new Properties() );
+
+        assertEquals( "value value", value );
+    }
+
+    @Test
     public void malformedPlaceholderIsLeftAsIs()
         throws MojoFailureException
     {
@@ -136,6 +149,25 @@ public class PropertyResolverTest
         assertEquals( "value", value2 );
         assertNull( value5 );
         assertNull( value6 );
+    }
+
+    @Test
+    public void circularReferenceIsIllegal()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "${p2}" );
+        properties.setProperty( "p2", "${p1}}" );
+
+        String value = null;
+        try {
+            value = resolver.getPropertyValue( "p2", properties, new Properties() );
+        } catch (IllegalArgumentException e) {
+            assertThat( e.getMessage(), containsString("p1"));
+            assertThat( e.getMessage(), containsString("p2"));
+        }
+
+        assertNull(value);
     }
 
     @Test


### PR DESCRIPTION
...plus minor fix to avoid side effects on ExpansionBuffer::toString
