### PR TITLE
Added HOCON config file support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
       <artifactId>maven-plugin-annotations</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>com.typesafe</groupId>
+      <artifactId>config</artifactId>
+      <version>1.2.1</version>
+    </dependency>
 
   </dependencies>
 

--- a/src/main/java/org/codehaus/mojo/properties/HoconProperties.java
+++ b/src/main/java/org/codehaus/mojo/properties/HoconProperties.java
@@ -1,0 +1,75 @@
+package org.codehaus.mojo.properties;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
+
+import java.io.File;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * A basic HOCON parser.
+  */
+public class HoconProperties {
+
+  private boolean respectHierarchy;
+
+  private HoconProperties(boolean respectHierarchy) {
+    this.respectHierarchy = respectHierarchy;
+  }
+
+  // Loosely based on Slick's GlobalConfig#toProperties()
+  // https://github.com/slick/slick/blob/3.1.0/slick/src/main/scala/slick/util/GlobalConfig.scala#L62
+  private Properties parse(ConfigObject config) {
+
+    Properties properties = new Properties();
+
+    for (Map.Entry<String, ConfigValue> configEntry : config.entrySet()) {
+
+      final Object value;
+
+      if (configEntry.getValue().valueType().equals(ConfigValueType.OBJECT)) {
+        value = parse((ConfigObject) configEntry.getValue());
+      } else if (configEntry.getValue().unwrapped() == null) {
+        value = null;
+      } else {
+        value = configEntry.getValue().unwrapped().toString();
+      }
+
+      if (!respectHierarchy && value != null && value instanceof Properties) {
+        for (Map.Entry<Object, Object> e : ((Properties) value).entrySet()) {
+          properties.put(configEntry.getKey() + "." + e.getKey(), e.getValue());
+        }
+      } else if (value != null) {
+        properties.put(configEntry.getKey(), value);
+      }
+    }
+
+    return properties;
+  }
+
+  public Properties parse(File file) {
+    Config config = ConfigFactory.parseFile(file);
+    return toProperties(config);
+  }
+
+  public Properties parse(String conf) {
+    Config config = ConfigFactory.parseString(conf);
+    return toProperties(config);
+  }
+
+  public Properties toProperties(Config conf) {
+    return parse(conf.root());
+  }
+
+  public static HoconProperties respectHierarchy() {
+    return new HoconProperties(true);
+  }
+
+  public static HoconProperties ignoreHierarchy() {
+    return new HoconProperties(false);
+  }
+}

--- a/src/test/java/org/codehaus/mojo/properties/HoconPropertiesTest.java
+++ b/src/test/java/org/codehaus/mojo/properties/HoconPropertiesTest.java
@@ -1,7 +1,11 @@
 package org.codehaus.mojo.properties;
 
 import static org.junit.Assert.assertEquals;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 import org.junit.Test;
+
+import java.io.File;
 import java.util.Properties;
 
 /**
@@ -68,4 +72,40 @@ public class HoconPropertiesTest {
     assertEquals(c.getProperty("d"), "aValue");
   }
 
+  @Test
+  public void testParsingWithUnResolvablePlaceHolder() throws Exception {
+
+    final String hoconf =
+            "a=${aValue}\n"
+            + "b=1\n"
+            + "c=anotherVal\n";
+
+    final Properties properties = HoconProperties.ignoreHierarchy().parse(hoconf);
+
+    final int twoValues = 2;
+
+    assertEquals(properties.size(), twoValues);
+    assertEquals(properties.getProperty("b"), "1");
+    assertEquals(properties.getProperty("c"), "anotherVal");
+  }
+
+  @Test
+  public void testParsingWithResolvablePlaceHolder() throws Exception {
+
+    final String hoconf =
+        "aValue = bValue\n"
+            + "a=${aValue}\n"
+            + "b=1\n"
+            + "c=anotherVal\n";
+
+    final Properties properties = HoconProperties.ignoreHierarchy().parse(hoconf);
+
+    final int fourValues = 4;
+
+    assertEquals(properties.size(), fourValues);
+    assertEquals(properties.getProperty("aValue"), "bValue");
+    assertEquals(properties.getProperty("a"), "bValue");
+    assertEquals(properties.getProperty("b"), "1");
+    assertEquals(properties.getProperty("c"), "anotherVal");
+  }
 }

--- a/src/test/java/org/codehaus/mojo/properties/HoconPropertiesTest.java
+++ b/src/test/java/org/codehaus/mojo/properties/HoconPropertiesTest.java
@@ -1,0 +1,71 @@
+package org.codehaus.mojo.properties;
+
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import java.util.Properties;
+
+/**
+ * A test class for the {@link HoconProperties} class.
+ */
+public class HoconPropertiesTest {
+
+  @Test
+  public void testParsingFlatConf() throws Exception {
+
+    final String hoconf =
+        "a=\"aValue\"\n"
+        + "b=1\n"
+        + "c=anotherVal\n";
+
+    final Properties properties = HoconProperties.ignoreHierarchy().parse(hoconf);
+
+    final int threeValues = 3;
+
+    assertEquals(properties.size(), threeValues);
+    assertEquals(properties.getProperty("a"), "aValue");
+    assertEquals(properties.getProperty("b"), "1");
+    assertEquals(properties.getProperty("c"), "anotherVal");
+  }
+
+  @Test
+  public void testParsingHierarchicalConfWithIgnoreHierarchy() throws Exception {
+
+    final String hoconf =
+      "a {\n"
+          + "  b {\n"
+          + "    c.d = aValue\n"
+          + "  }\n"
+          + "}\n";
+
+    final Properties properties = HoconProperties.ignoreHierarchy().parse(hoconf);
+
+    final int oneValue = 1;
+    assertEquals(properties.size(), oneValue);
+    assertEquals(properties.getProperty("a.b.c.d"), "aValue");
+  }
+
+  @Test
+  public void testParsingHierarchicalConfWithRespectHierarchy() throws Exception {
+
+    final String hoconf =
+        "a {\n"
+            + "  b {\n"
+            + "    c.d = aValue\n"
+            + "  }\n"
+            + "}\n";
+
+    final Properties properties = HoconProperties.respectHierarchy().parse(hoconf);
+
+    final Properties a = (Properties) properties.get("a");
+    final Properties b = (Properties) a.get("b");
+    final Properties c = (Properties) b.get("c");
+
+    final int oneValue = 1;
+    assertEquals(properties.size(), oneValue);
+    assertEquals(a.size(), oneValue);
+    assertEquals(b.size(), oneValue);
+    assertEquals(c.size(), oneValue);
+    assertEquals(c.getProperty("d"), "aValue");
+  }
+
+}


### PR DESCRIPTION
Great plugin, thanks!

I've recently encountered a case where I need to use a [HOCON](https://github.com/typesafehub/config) based configuration file instead of Java's `Properties` so I added a support for reading such files.

Hope others can find it useful as well.