### PR TITLE
Nested properties resolver

### DIFF
--- a/src/main/java/org/codehaus/mojo/properties/IPropertyResolver.java
+++ b/src/main/java/org/codehaus/mojo/properties/IPropertyResolver.java
@@ -1,0 +1,8 @@
+package org.codehaus.mojo.properties;
+
+import java.util.Properties;
+
+public interface IPropertyResolver {
+    
+    public String getPropertyValue( String key, Properties properties, Properties environment );
+}

--- a/src/main/java/org/codehaus/mojo/properties/NestedPropertyResolver.java
+++ b/src/main/java/org/codehaus/mojo/properties/NestedPropertyResolver.java
@@ -1,0 +1,153 @@
+package org.codehaus.mojo.properties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Properties;
+import java.util.Set;
+import java.util.Stack;
+import java.util.TreeSet;
+
+class NestedPropertyResolver implements IPropertyResolver
+{
+
+    /**
+     * Retrieves a property value, replacing values like ${token} using the Properties to look them up. Shamelessly
+     * adapted from:
+     * http://maven.apache.org/plugins/maven-war-plugin/xref/org/apache/maven/plugin/war/PropertyUtils.html It will
+     * leave unresolved properties alone, trying for System properties, and environment variables and implements
+     * reparsing (in the case that the value of a property contains a key), and will not loop endlessly on a pair like
+     * test = ${test}
+     *
+     * @param key property key
+     * @param properties project properties
+     * @param environment environment variables
+     * @return resolved property value
+     * @throws IllegalArgumentException when properties are circularly defined
+     */
+    static final String START_PLACEHOLDER = "${";
+    static final String END_PLACEHOLDER = "}";
+    static final String DELIMITER = ":";
+
+    public String getPropertyValue( String key, Properties properties, Properties environment )
+    {
+        Stack<String> visited = new Stack<String>();
+        Set<String> unresolved = new TreeSet<String>();
+
+        key = resolveValue(key, properties, environment, visited, unresolved);
+        String value = properties.getProperty(key);
+        value = resolveValue(value, properties, environment, visited, unresolved);
+
+//        properties.put(key, value);
+//        System.out.println("############-=RESULTS=-##############");
+//        System.out.println("Properties: " + properties);
+//        System.out.println("Unresolvable properties: " + unresolved);
+//        System.out.println("Key: " + key + " Value: " + value + "\n\n");
+
+        return value;
+    }
+
+    private String resolveValue( String value, Properties properties, Properties environment, Stack<String> visited, Set<String> unresolved )
+    {
+        String buffer = value != null ? value : "";
+
+        String newKey;
+        while ((newKey = findInnermostPlaceholders(buffer, unresolved)) != null )
+        {
+            String originalKey = newKey;
+            String defaultValue = null;
+            if(newKey.contains(DELIMITER)) {
+                String[] split = removePlaceholder(newKey).split(":",2);
+                defaultValue = split[1];
+                newKey = START_PLACEHOLDER + split[0] + END_PLACEHOLDER;
+            }
+            visited.push(newKey);
+            String cleanNewKey = removePlaceholder(newKey);
+            String newValue = fromPropertiesThenSystemThenEnvironment(cleanNewKey, properties, environment);
+            if(newValue != null) {
+                if(newValue.startsWith(START_PLACEHOLDER) && visited.contains(newValue)) {
+                    String err = "Circular Reference to " +  newValue + " found cannot continue";
+                    throw new IllegalArgumentException(err);
+                } else if(newValue.contains(START_PLACEHOLDER)) {
+                    newValue = resolveValue(newValue, properties, environment, visited, unresolved);
+                    properties.put(cleanNewKey, newValue);
+                }
+            } else {
+                unresolved.add(newKey);
+            }
+            //Set default value if necessary
+            if((newValue == null || unresolved.contains(newValue)) && defaultValue != null) {
+                newValue = defaultValue;
+            }
+            if(newValue != null) {
+                buffer = buffer.replace(originalKey, newValue);
+            }
+            visited.pop();
+        }
+        return buffer;
+    }
+
+    private String removePlaceholder(String key) {
+        return key.substring(2,key.length()-1);
+    }
+
+    private String findInnermostPlaceholders(String buffer, Set<String> unresolved)
+    {
+        Stack<Integer> q = new Stack<Integer>();
+        int endIndex = -1;
+        for(int i=0;i<buffer.length();i++) {
+            if(i < (buffer.length() - (START_PLACEHOLDER.length() - 1)) && buffer.substring(i).startsWith(START_PLACEHOLDER)) {
+                q.add(i);
+            } else if(buffer.substring(i).startsWith(END_PLACEHOLDER) && !q.isEmpty()) {
+                endIndex = i+1;
+                String key = buffer.substring(q.pop(), endIndex);
+                if(unresolved.contains(key)) {
+                    continue;
+                }
+                return key;
+            }
+        }
+        return null;
+    }
+
+    private String fromPropertiesThenSystemThenEnvironment( String key, Properties properties, Properties environment )
+    {
+        if(key.equals("")) { //empty place holder is always unresolved
+            return null;
+        }
+        String value = properties.getProperty( key );
+
+        // try global environment
+        if ( value == null )
+        {
+            value = System.getProperty( key );
+        }
+
+        // try environment variable
+        if ( value == null && key.startsWith( "env." ) && environment != null )
+        {
+            value = environment.getProperty( key.substring( 4 ) );
+        }
+
+        return value;
+    }
+}

--- a/src/main/java/org/codehaus/mojo/properties/PropertyResolver.java
+++ b/src/main/java/org/codehaus/mojo/properties/PropertyResolver.java
@@ -21,7 +21,7 @@ package org.codehaus.mojo.properties;
 
 import java.util.Properties;
 
-class PropertyResolver
+class PropertyResolver implements IPropertyResolver
 {
 
     /**

--- a/src/main/java/org/codehaus/mojo/properties/ReadPropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/properties/ReadPropertiesMojo.java
@@ -54,6 +54,13 @@ public class ReadPropertiesMojo
     @Parameter( defaultValue = "${project}", readonly = true, required = true )
     private MavenProject project;
 
+    @Parameter( defaultValue = "false", required = false )
+    private boolean useNestedPropertyResolver;
+
+    public void setUseNestedPropertyResolver(boolean useNestedPropertyResolver) {
+        this.useNestedPropertyResolver = useNestedPropertyResolver;
+    }
+
     /**
      * The properties files that will be used when reading properties.
      */
@@ -123,7 +130,7 @@ public class ReadPropertiesMojo
     /**
      * Used for resolving property placeholders.
      */
-    private final PropertyResolver resolver = new PropertyResolver();
+    private IPropertyResolver resolver;
 
     /** {@inheritDoc} */
     public void execute()
@@ -134,6 +141,12 @@ public class ReadPropertiesMojo
         loadFiles();
 
         loadUrls();
+
+        if(useNestedPropertyResolver) {
+            resolver = new NestedPropertyResolver();
+        } else {
+            resolver = new PropertyResolver();
+        }
 
         resolveProperties();
     }

--- a/src/test/java/org/codehaus/mojo/properties/NestedPropertyResolverTest.java
+++ b/src/test/java/org/codehaus/mojo/properties/NestedPropertyResolverTest.java
@@ -1,0 +1,549 @@
+package org.codehaus.mojo.properties;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.apache.maven.plugin.MojoFailureException;
+import java.util.Properties;
+
+/**
+ * Tests the support class that produces concrete values from a set of properties.
+ */
+public class NestedPropertyResolverTest
+{
+    private final NestedPropertyResolver resolver = new NestedPropertyResolver();
+
+    @Test
+    public void validPlaceholderIsResolved()
+        throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "${p2}" );
+        properties.setProperty( "p2", "value" );
+
+        String value1 = resolver.getPropertyValue( "p1", properties, new Properties() );
+        String value2 = resolver.getPropertyValue( "p2", properties, new Properties() );
+
+        assertEquals( "value", value1 );
+        assertEquals( "value", value2 );
+    }
+
+    @Test
+    public void unknownPlaceholderIsLeftAsIs()
+        throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "${p2}" );
+        properties.setProperty( "p2", "value" );
+        properties.setProperty( "p3", "${unknown}" );
+
+        String value1 = resolver.getPropertyValue( "p1", properties, new Properties() );
+        String value2 = resolver.getPropertyValue( "p2", properties, new Properties() );
+        String value3 = resolver.getPropertyValue( "p3", properties, new Properties() );
+
+        assertEquals( "value", value1 );
+        assertEquals( "value", value2 );
+        assertEquals( "${unknown}", value3 );
+    }
+
+    @Test
+    public void multipleValuesAreResolved()
+        throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "hostname", "localhost" );
+        properties.setProperty( "port", "8080" );
+        properties.setProperty( "base.url", "http://${hostname}:${port}/" );
+
+        String value = resolver.getPropertyValue( "base.url", properties, new Properties() );
+
+        assertEquals( "http://localhost:8080/", value );
+    }
+
+    @Test
+    public void propertyIncludesAnotherPropertyMoreThanOnce()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "value" );
+        properties.setProperty( "p2", "${p1} ${p1}" );
+
+        String value = resolver.getPropertyValue( "p2", properties, new Properties() );
+
+        assertEquals( "value value", value );
+    }
+
+    @Test
+    public void malformedPlaceholderIsLeftAsIs()
+        throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "${p2}" );
+        properties.setProperty( "p2", "value" );
+        properties.setProperty( "p4", "${malformed" );
+
+        String value1 = resolver.getPropertyValue( "p1", properties, new Properties() );
+        String value2 = resolver.getPropertyValue( "p2", properties, new Properties() );
+        String value4 = resolver.getPropertyValue( "p4", properties, new Properties() );
+
+        assertEquals( "value", value1 );
+        assertEquals( "value", value2 );
+        assertEquals( "${malformed", value4 );
+    }
+
+    @Test
+    public void propertyDefinedAsItselfIsIllegal()
+        throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "${p2}" );
+        properties.setProperty( "p2", "value" );
+        properties.setProperty( "p5", "${p5}" );
+        properties.setProperty( "p6", "${p7}" );
+        properties.setProperty( "p7", "${p6}" );
+
+        String value1 = resolver.getPropertyValue( "p1", properties, new Properties() );
+        String value2 = resolver.getPropertyValue( "p2", properties, new Properties() );
+        String value5 = null;
+        try
+        {
+            value5 = resolver.getPropertyValue( "p5", properties, new Properties() );
+            fail();
+        }
+        catch ( IllegalArgumentException e )
+        {
+            assertThat( e.getMessage(), containsString( "p5" ) );
+        }
+        String value6 = null;
+        try
+        {
+            value6 = resolver.getPropertyValue( "p6", properties, new Properties() );
+            fail();
+        }
+        catch ( IllegalArgumentException e )
+        {
+            assertThat( e.getMessage(), containsString( "p7" ) );
+        }
+
+        assertEquals( "value", value1 );
+        assertEquals( "value", value2 );
+        assertNull( value5 );
+        assertNull( value6 );
+    }
+
+    @Test
+    public void circularReferenceIsIllegal()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "${p2}" );
+        properties.setProperty( "p2", "${p1}" );
+
+        String value = null;
+        try {
+            value = resolver.getPropertyValue( "p2", properties, new Properties() );
+        } catch (IllegalArgumentException e) {
+            assertThat( e.getMessage(), containsString("p1"));
+            assertThat( e.getMessage(), containsString("p1"));
+        }
+
+        assertNull(value);
+    }
+
+    @Test
+    public void valueIsObtainedFromSystemProperty()
+        throws MojoFailureException
+    {
+        Properties saved = System.getProperties();
+        System.setProperty( "system.property", "system.value" );
+
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "${system.property}" );
+
+        String value = resolver.getPropertyValue( "p1", properties, new Properties() );
+
+        try
+        {
+            assertEquals( "system.value", value );
+        }
+        finally
+        {
+            System.setProperties( saved );
+        }
+    }
+
+    @Test
+    public void valueIsObtainedFromEnvironmentProperty()
+        throws MojoFailureException
+    {
+        Properties environment = new Properties();
+        environment.setProperty( "PROPERTY", "env.value" );
+
+        Properties properties = new Properties();
+        properties.setProperty( "p1", "${env.PROPERTY}" );
+
+        String value = resolver.getPropertyValue( "p1", properties, environment );
+
+        assertEquals( "env.value", value );
+    }
+
+    @Test
+    public void missingPropertyIsTolerated()
+    {
+        assertEquals( "", resolver.getPropertyValue( "non-existent", new Properties(), null ) );
+    }
+
+    @Test
+    public void nestedPropertiesTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "n", "n" );
+        properties.setProperty( "N", "${n}" );
+        properties.setProperty( "x", "${y}" );
+        properties.setProperty( "y", "${z}" );
+        properties.setProperty( "z", "z" );
+        properties.setProperty( "Z", "Z" );
+        properties.setProperty( "Nest", "${${Z}${x}}");
+        properties.setProperty( "Zz", "${N}");
+        properties.setProperty( "p1", "${${one}${five}four${o${Nest}e}five}" );
+        properties.setProperty( "p2", "${p1}" );
+        properties.setProperty( "p3", "${p2}" );
+        properties.setProperty( "p4", "${p${three}}");
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "p4", properties, new Properties() );
+
+//            value = resolver.getPropertyValue( "p3", properties, new Properties() );
+        assertEquals(value, "15415");
+    }
+
+    @Test
+    public void nestedPropertiesUnresolvedTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "n", "n${unresolved}" );
+        properties.setProperty( "N", "${n}" );
+        properties.setProperty( "x", "${y}" );
+        properties.setProperty( "y", "${z}" );
+        properties.setProperty( "z", "z" );
+        properties.setProperty( "Z", "Z" );
+        properties.setProperty( "Nest", "${${Z}${x}}");
+        properties.setProperty( "Zz", "${N}");
+        properties.setProperty( "p1", "${${one}${five}four${o${Nest}e}five}" );
+        properties.setProperty( "p2", "${p1}" );
+        properties.setProperty( "p3", "${p2}" );
+        properties.setProperty( "p4", "${p${three}}");
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "p4", properties, new Properties() );
+
+        assertEquals(value, "${15four${on${unresolved}e}five}");
+    }
+
+    @Test
+    public void nestedCircularReferenceTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "N", "n" );
+        properties.setProperty( "p1", "${${one}${five}four${o${N${p2}}e}five}" );
+        properties.setProperty( "p2", "${p3}" );
+        properties.setProperty( "p3", "${p4}" );
+        properties.setProperty( "p4", "${${one}${five}four${o${N${p3}}e}five}" );
+
+        String value = null;
+        try {
+            value = resolver.getPropertyValue( "p1", properties, new Properties() );
+            assertEquals(value, "15415");
+        } catch (IllegalArgumentException e) {
+            assertThat( e.getMessage(), containsString("p4"));
+        }
+    }
+
+    @Test
+    public void nestedPropertiesDefaultValueTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "realn", "n" );
+        properties.setProperty( "realunresolved", "${unresolved}" );
+        properties.setProperty( "n", "${realunresolved:${realn}}" );
+        properties.setProperty( "N", "${n}" );
+        properties.setProperty( "x", "${y}" );
+        properties.setProperty( "y", "${z}" );
+        properties.setProperty( "z", "z" );
+        properties.setProperty( "Z", "Z" );
+        properties.setProperty( "Nest", "${${Z}${x}}");
+        properties.setProperty( "Zz", "${N}");
+        properties.setProperty( "p1", "${${one}${fiver:5}four${o${Nest}e}five}" );
+        properties.setProperty( "p2", "${p1}" );
+        properties.setProperty( "p3", "${p2}" );
+        properties.setProperty( "p4", "${p${three}}");
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "p4", properties, new Properties() );
+
+        assertEquals(value, "15415");
+    }
+
+
+    @Test
+    public void nestedPropertiesUnresolvedValueTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "realn", "n" );
+        properties.setProperty( "realunresolved", "${unresolved}" );
+        properties.setProperty( "n", "${realunresolved:${realn}}" );
+        properties.setProperty( "N", "${n}" );
+        properties.setProperty( "x", "${y}" );
+        properties.setProperty( "y", "${z}" );
+        properties.setProperty( "z", "z" );
+        properties.setProperty( "Z", "Z" );
+        properties.setProperty( "Nest", "${${Z}${x}}");
+        properties.setProperty( "Zz", "${N}");
+        properties.setProperty( "p1", "${fiver}${${one}${fiver:5}four${o${Nest}e}five}${fiver}" );
+        properties.setProperty( "p2", "${p1}" );
+        properties.setProperty( "p3", "${p2}" );
+        properties.setProperty( "p4", "${p${three}}");
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "p4", properties, new Properties() );
+
+        assertEquals(value, "${fiver}15415${fiver}");
+    }
+
+    @Test
+    public void nestedDefaultValueTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "realn", "n" );
+        properties.setProperty( "realunresolved", "${unresolved}" );
+        properties.setProperty( "n", "${realunresolved:${realn}}" );
+        properties.setProperty( "N", "${n}" );
+        properties.setProperty( "x", "${y}" );
+        properties.setProperty( "y", "${z}" );
+        properties.setProperty( "z", "z" );
+        properties.setProperty( "Z", "Z" );
+        properties.setProperty( "Nest", "${${Z}${x}}");
+        properties.setProperty( "Zz", "${N}");
+        properties.setProperty( "p1", "${Nest:${fiver:5}}${realUnresolved:${x:NOTX}}${realUnresolved:${nothing:NOTX}}" );
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "p1", properties, new Properties() );
+
+        assertEquals(value, "nzNOTX");
+    }
+
+    @Test
+    public void nestedKeyVariableTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "realn", "n" );
+        properties.setProperty( "realunresolved", "${unresolved}" );
+        properties.setProperty( "n", "${realunresolved:${realn}}" );
+        properties.setProperty( "N", "${n}" );
+        properties.setProperty( "x", "${y}" );
+        properties.setProperty( "y", "${z}" );
+        properties.setProperty( "z", "z" );
+        properties.setProperty( "Z", "Z" );
+        properties.setProperty( "Nest", "${${Z}${x}}");
+        properties.setProperty( "Zz", "${N}");
+        properties.setProperty( "p1", "${Nest:${fiver:5}}${realUnresolved:${x:NOTX}}${realUnresolved:${nothing:NOTX}}" );
+
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "p${one}", properties, new Properties() );
+
+        assertEquals(value, "nzNOTX");
+    }
+
+    @Test
+    public void nestedPropertiesEmptyTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "realn", "n" );
+        properties.setProperty( "realunresolved", "${unresolved}" );
+        properties.setProperty( "n", "${realunresolved:${realn}}" );
+        properties.setProperty( "N", "${n}" );
+        properties.setProperty( "x", "${y}" );
+        properties.setProperty( "y", "${z}" );
+        properties.setProperty( "z", "z" );
+        properties.setProperty( "Z", "Z" );
+        properties.setProperty( "Nest", "${${Z}${x}}");
+        properties.setProperty( "Zz", "${N}");
+        properties.setProperty( "p1", "${fiver}${${one}${fiver:5}four${o${Nest}e}five}${fiver}" );
+        properties.setProperty( "p2", "${p1}" );
+        properties.setProperty( "p3", "${p2}" );
+        properties.setProperty( "p4", "${${p1}${}${");
+        properties.setProperty( "p5", "{${${p1}$");
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "p4", properties, new Properties() );
+
+        assertEquals(value, "${${fiver}15415${fiver}${}${");
+
+        value = resolver.getPropertyValue( "p5", properties, new Properties() );
+
+        assertEquals(value, "{${${fiver}15415${fiver}$");
+    }
+
+
+    @Test
+    public void nestedPropertiesEmptyDefaultValueTest()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+        properties.setProperty( "one", "1" );
+        properties.setProperty( "two", "2" );
+        properties.setProperty( "three", "3" );
+        properties.setProperty( "four", "4" );
+        properties.setProperty( "five", "5" );
+        properties.setProperty( "5five", "55" );
+        properties.setProperty( "15five", "155" );
+        properties.setProperty( "15fourfive", "1545" );
+        properties.setProperty( "15four1five", "15415" );
+        properties.setProperty( "realn", "n" );
+        properties.setProperty( "realunresolved", "${unresolved}" );
+        properties.setProperty( "n", "${realunresolved:${realn}}" );
+        properties.setProperty( "N", "${n}" );
+        properties.setProperty( "x", "${y}" );
+        properties.setProperty( "y", "${z}" );
+        properties.setProperty( "z", "z" );
+        properties.setProperty( "Z", "Z" );
+        properties.setProperty( "Nest", "${${Z}${x}}");
+        properties.setProperty( "Zz", "${N}");
+        properties.setProperty( "p1", "${one}${fiver:}${:1}${:${one}}${:}" );
+        properties.setProperty( "p2", "${p1}" );
+        properties.setProperty( "p3", "${p2}" );
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "p3", properties, new Properties() );
+
+        assertEquals(value, "111");
+
+    }
+
+    @Test
+    public void nestedPropertiesDoubleUnresolved()
+            throws MojoFailureException
+    {
+        Properties properties = new Properties();
+
+        properties.setProperty( "a", "${unresolved}" );
+        properties.setProperty( "b", "${unresolved}" );
+        properties.setProperty( "c", "${a}${a}${b}" );
+
+        String value = null;
+
+        value = resolver.getPropertyValue( "c", properties, new Properties() );
+
+        assertEquals(value, "${unresolved}${unresolved}${unresolved}");
+
+    }
+}


### PR DESCRIPTION
This PR will allow nested properties to be resolved if enabled.  To enabled this resolver use the following configuration:

```
<configuration>
    <useNestedPropertyResolver>true</useNestedPropertyResolver>
    ...
</configuration>
```

Simple example of nested properties that can be resolved (see unit test for more):

```
one=1
1=HI
xyz=${${one}}

```
Result xyz=HI

Real world example:

global config file contains http ports for all projects so there is no port overlaps:
```
project1.port=8080
project2.port=8081
project3.port=8083
dockerPort=${${project-artifactId}.port}
```

Inside parent pom you can set:


```
<!--This is needed because "model interpolated" properties are not in the project properties map-->
<project-artifactId>${project.artifactId}</project-artifactId>
<port>${dockerPort}</port>
```


