### PR TITLE
Add the possibility to exclude some keys to write or/and generate (or not) the comment header with the timestamp

### DIFF
--- a/src/main/java/org/codehaus/mojo/properties/PropertiesWithoutHeader.java
+++ b/src/main/java/org/codehaus/mojo/properties/PropertiesWithoutHeader.java
@@ -1,0 +1,59 @@
+package org.codehaus.mojo.properties;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * PropertiesWithoutHeader
+ *
+ * Properties without writing header comment and generated timestamp at the beginning of the properties file
+ *
+ */
+public class PropertiesWithoutHeader extends Properties {
+
+    private static final long serialVersionUID = 8667775349218327383L;
+
+    private static class SkipFirstLineStream extends FilterOutputStream {
+
+        private boolean firstLineDetected = false;
+
+        public SkipFirstLineStream(final OutputStream out) {
+            super(out);
+        }
+
+        @Override
+        public void write(final int b) throws IOException {
+            if (firstLineDetected) {
+                super.write(b);
+            } else if (b == '\n') {
+                firstLineDetected = true;
+            }
+        }
+    }
+
+    @Override
+    public void store(final OutputStream out, final String comments) throws IOException {
+        super.store(new SkipFirstLineStream(out), null);
+    }
+}


### PR DESCRIPTION
Add the possibility to exclude some keys to write and generate (or not) the comment header with the timestamp.

I need to generate properties file but without some property keys (notably the generated based on random value or timestamp value or environment based) and need not to have the timestamp of the generation of the properties.
It permits have exactly the same properties file in order not to have some conflicts based on these generated properties.

I added the exclusionRegex parameter (not required) to exclude some keys.
I added the generateCommentHeader parameter (not required, defauted to true) to remove the comment header (or not).

If you don't set the 2 parameters, the generation of the properties file is back-compatible.

Don't hesitate if you have any comment on the pull-request.