### PR TITLE
Add skip capability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>org.codehaus.mojo</groupId>
   <artifactId>properties-maven-plugin</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.2-skip</version>
 
   <name>Properties Maven Plugin</name>
   <description> 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>org.codehaus.mojo</groupId>
   <artifactId>properties-maven-plugin</artifactId>
-  <version>1.0.2-skip</version>
+  <version>1.0.1-SNAPSHOT</version>
 
   <name>Properties Maven Plugin</name>
   <description> 

--- a/src/main/java/org/codehaus/mojo/properties/ReadPropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/properties/ReadPropertiesMojo.java
@@ -120,6 +120,9 @@ public class ReadPropertiesMojo
         this.keyPrefix = keyPrefix;
     }
 
+    @Parameter( defaultValue = "false" , property = "prop.skipLoadProperties")
+    private boolean skipLoadProperties;
+
     /**
      * Used for resolving property placeholders.
      */
@@ -129,13 +132,17 @@ public class ReadPropertiesMojo
     public void execute()
         throws MojoExecutionException, MojoFailureException
     {
-        checkParameters();
+        if ( !this.skipLoadProperties ) {
+            checkParameters();
 
-        loadFiles();
+            loadFiles();
 
-        loadUrls();
+            loadUrls();
 
-        resolveProperties();
+            resolveProperties();
+        } else {
+            getLog().warn("The properties are ignored");
+        }
     }
 
     private void checkParameters()
@@ -306,6 +313,15 @@ public class ReadPropertiesMojo
     void setQuiet( boolean quiet )
     {
         this.quiet = quiet;
+    }
+
+    /**
+     *
+     * @param skipLoadProperties Set to <code>true</code> if you don't want to load properties.
+     */
+    void setSkipLoadProperties( boolean skipLoadProperties )
+    {
+        this.skipLoadProperties = skipLoadProperties;
     }
 
     /**


### PR DESCRIPTION
it can be useful to dynamically skip the import of the properties so a new parameter `skipLoadProperties` has been added and it can be set using property from command line `prop.skipLoadProperties` (i.e. `-Dprop.skipLoadProperties=true` )