### PR TITLE
updated read part to fix spring security url read

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>org.codehaus.mojo</groupId>
   <artifactId>properties-maven-plugin</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.0.1-NG</version>
 
   <name>Properties Maven Plugin</name>
   <description> 


### PR DESCRIPTION
Was getting 403 wheni was trying to read property from spring cloud server.
Spring Cloud config server with security was not working here where we have URL with SSL, for .e.g https://username:password@example-server.com/config-dev.properties. this pull request modify capability to load URL with proper header (User agent) .