### PR TITLE
excludes configuration was developed

### DIFF
--- a/src/main/java/org/codehaus/mojo/properties/AbstractWritePropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/properties/AbstractWritePropertiesMojo.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
 
 /*
@@ -61,6 +62,29 @@ public abstract class AbstractWritePropertiesMojo
 
     @Parameter( required = true )
     private File outputFile;
+
+    @Parameter( )
+    private List<String> excludes;
+
+    /**
+     * Filter the properties out, which are listed in the exclude list.
+     *
+     * @param properties all the properties
+     * @return the filtered properties
+     */
+    // this whole method was written by GitHub CoPilot, I only wrote the method header
+    protected Properties filterProperties(Properties properties ){
+        Properties filteredProperties = new Properties();
+        for ( String key : properties.stringPropertyNames() )
+        {
+            if ( excludes != null && excludes.contains( key ) )
+            {
+                continue;
+            }
+            filteredProperties.put( key, properties.getProperty( key ) );
+        }
+        return filteredProperties;
+    }
 
     /**
      * @param properties {@link Properties}

--- a/src/main/java/org/codehaus/mojo/properties/WriteActiveProfileProperties.java
+++ b/src/main/java/org/codehaus/mojo/properties/WriteActiveProfileProperties.java
@@ -55,6 +55,6 @@ public class WriteActiveProfileProperties
             }
         }
 
-        writeProperties( properties, getOutputFile() );
+        writeProperties( filterProperties(properties), getOutputFile() );
     }
 }

--- a/src/main/java/org/codehaus/mojo/properties/WriteProjectProperties.java
+++ b/src/main/java/org/codehaus/mojo/properties/WriteProjectProperties.java
@@ -79,6 +79,6 @@ public class WriteProjectProperties
 
         }
 
-        writeProperties( projProperties, getOutputFile() );
+        writeProperties( filterProperties(projProperties), getOutputFile() );
     }
 }

--- a/src/site/apt/usage.apt.vm
+++ b/src/site/apt/usage.apt.vm
@@ -94,6 +94,9 @@ Usage
               <outputFile>
                 \${project.build.outputDirectory}/app.properties
               </outputFile>
+              <excludes>
+                <exclude>gpg.password</exclude>
+              </excludes>
             </configuration>
           </execution>
         </executions>
@@ -126,6 +129,9 @@ Usage
               <outputFile>
                 \${project.build.outputDirectory}/app.properties
               </outputFile>
+              <excludes>
+                <exclude>gpg.password</exclude>
+              </excludes>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
When writing the project properties to a properties file it writes all the properties including those defined in the `~/.m2/settings.xml` file. Some of these properties are sensitive, for example, `gpg.password` I use to sign the projects to deploy to maven central.

This patch adds an optional `excludes/exclude` property where the user can list the properties that they do not want to be dumped to the output file.