### PR TITLE
Add encoding parameter to read and write properties files

### DIFF
--- a/src/main/java/org/codehaus/mojo/properties/AbstractWritePropertiesMojo.java
+++ b/src/main/java/org/codehaus/mojo/properties/AbstractWritePropertiesMojo.java
@@ -32,6 +32,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.StringReader;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,12 +45,51 @@ import java.io.BufferedReader;
 public abstract class AbstractWritePropertiesMojo
     extends AbstractMojo
 {
+    /**
+     * Default encoding for the output file. Package private for testing.
+     */
+    static final String DEFAULT_ENCODING = "ISO-8859-1";
 
     @Parameter( defaultValue = "${project}", required = true, readonly = true )
     private MavenProject project;
 
     @Parameter( required = true, property = "properties.outputFile" )
     private File outputFile;
+
+    /**
+     * The encoding to use when writing the properties file.
+     */
+    @Parameter( required = false, defaultValue = DEFAULT_ENCODING )
+    private String encoding = DEFAULT_ENCODING;
+
+    /**
+     * Default scope for test access.
+     *
+     * @param project The test project.
+     */
+    void setProject( MavenProject project )
+    {
+        this.project = project;
+    }
+
+    /**
+     * Default scope for test access.
+     *
+     * @param encoding to write the output file in
+     */
+    void setEncoding( String encoding )
+    {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Default scope for test access
+     *
+     * @param outputFile the outputFile to set
+     */
+    void setOutputFile(File outputFile) {
+        this.outputFile = outputFile;
+    }
 
     /**
      * @param properties {@link Properties}
@@ -59,6 +99,8 @@ public abstract class AbstractWritePropertiesMojo
     protected void writeProperties( Properties properties, File file )
         throws MojoExecutionException
     {
+        getLog().debug( String.format( "Writing properties to %s using encoding %s", file.toString(),  this.encoding ) );
+
         try
         {
             storeWithoutTimestamp( properties, file, "Properties" );
@@ -79,7 +121,7 @@ public abstract class AbstractWritePropertiesMojo
     private void storeWithoutTimestamp( Properties properties, File outputFile, String comments )
         throws IOException
     {
-        try ( PrintWriter pw = new PrintWriter( outputFile, "ISO-8859-1" ); StringWriter sw = new StringWriter() )
+        try ( PrintWriter pw = new PrintWriter( outputFile, this.encoding ); StringWriter sw = new StringWriter() )
         {
             properties.store( sw, comments );
             comments = '#' + comments;
@@ -122,6 +164,21 @@ public abstract class AbstractWritePropertiesMojo
         }
     }
 
+    /**
+     * @throws MojoExecutionException {@link MojoExecutionException}
+     */
+    protected void validateEncoding()
+        throws MojoExecutionException
+    {
+        try
+        {
+            Charset.forName(this.encoding);
+        }
+        catch(IllegalArgumentException e)
+        {
+            throw new MojoExecutionException(String.format("Invalid encoding '%s'", this.encoding), e);
+        }
+    }
     /**
      * @return {@link MavenProject}
      */

--- a/src/main/java/org/codehaus/mojo/properties/WriteActiveProfileProperties.java
+++ b/src/main/java/org/codehaus/mojo/properties/WriteActiveProfileProperties.java
@@ -41,6 +41,7 @@ public class WriteActiveProfileProperties
         throws MojoExecutionException
     {
         validateOutputFile();
+        validateEncoding();
         List<Profile> list = getProject().getActiveProfiles();
         if ( getLog().isInfoEnabled() )
         {

--- a/src/main/java/org/codehaus/mojo/properties/WriteProjectProperties.java
+++ b/src/main/java/org/codehaus/mojo/properties/WriteProjectProperties.java
@@ -60,6 +60,7 @@ public class WriteProjectProperties
         throws MojoExecutionException
     {
         validateOutputFile();
+        validateEncoding();
         Properties projProperties = new Properties();
         projProperties.putAll( getProject().getProperties() );
 

--- a/src/test/java/org/codehaus/mojo/properties/ReadPropertiesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/properties/ReadPropertiesMojoTest.java
@@ -1,22 +1,35 @@
 package org.codehaus.mojo.properties;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-
 public class ReadPropertiesMojoTest
 {
     private static final String NEW_LINE = System.getProperty( "line.separator" );
+
+    private static final Map<String, String> ISO_8859_REPRESENTABLE = Map.of( "test.property1", "value1®",
+                                                                              "test.property2", "value2" );
+
+    private static final Map<String, String> ISO_8859_NOT_REPRESENTABLE = Map.of ( "test.property3", "value3™",
+                                                                                   "test.property4", "κόσμε" );
 
     private MavenProject projectStub;
     private ReadPropertiesMojo readPropertiesMojo;
@@ -32,14 +45,21 @@ public class ReadPropertiesMojoTest
     @Test
     public void readPropertiesWithoutKeyprefix() throws Exception
     {
-        try ( FileReader fr = new FileReader( getPropertyFileForTesting() ) )
+        final Map<String, String> propMap = new HashMap<>();
+        propMap.putAll( ISO_8859_REPRESENTABLE );
+        propMap.putAll( ISO_8859_NOT_REPRESENTABLE );
+
+        final String encoding = ReadPropertiesMojo.DEFAULT_ENCODING;
+        File referenceFile = getPropertyFileForTesting( encoding, propMap );
+        try ( FileInputStream fileStream = new FileInputStream( referenceFile );
+              InputStreamReader fr = new InputStreamReader( fileStream, encoding ) )
         {
             // load properties directly for comparison later
             Properties testProperties = new Properties();
             testProperties.load( fr );
 
             // do the work
-            readPropertiesMojo.setFiles( new File[] {getPropertyFileForTesting()} );
+            readPropertiesMojo.setFiles( new File[] {getPropertyFileForTesting( encoding, propMap )} );
             readPropertiesMojo.execute();
 
             // check results
@@ -51,6 +71,22 @@ public class ReadPropertiesMojoTest
             // we are not adding prefix, so properties should be same as in file
             assertEquals( testProperties.size(), projectProperties.size() );
             assertEquals( testProperties, projectProperties );
+
+            // strings which are representable in ISO-8859-1 should match the source data
+            for ( String sourceKey : ISO_8859_REPRESENTABLE.keySet() )
+            {
+                assertEquals( ISO_8859_REPRESENTABLE.get( sourceKey ), projectProperties.getProperty( sourceKey ) );
+            }
+
+            // strings which are not representable in ISO-8859-1 underwent a conversion which lost data
+            for ( String sourceKey : ISO_8859_NOT_REPRESENTABLE.keySet() )
+            {
+                String sourceValue = ISO_8859_NOT_REPRESENTABLE.get( sourceKey );
+                String converted = new String( sourceValue.getBytes( encoding ), StandardCharsets.UTF_8 );
+                String propVal = projectProperties.getProperty( sourceKey );
+                assertNotEquals( sourceValue, propVal );
+                assertEquals( converted, propVal );
+            }
         }
     }
 
@@ -58,21 +94,28 @@ public class ReadPropertiesMojoTest
     public void readPropertiesWithKeyprefix() throws Exception
     {
         String keyPrefix = "testkey-prefix.";
+        final String encoding = ReadPropertiesMojo.DEFAULT_ENCODING;
 
-        try ( FileReader fs1 = new FileReader( getPropertyFileForTesting( keyPrefix ) );
-              FileReader fs2 = new FileReader( getPropertyFileForTesting() ) )
+        final Map<String, String> propMap = new HashMap<>();
+        propMap.putAll( ISO_8859_REPRESENTABLE );
+        propMap.putAll( ISO_8859_NOT_REPRESENTABLE );
+
+        try ( FileInputStream fs1 = new FileInputStream( getPropertyFileForTesting( keyPrefix, encoding, propMap ) );
+              FileInputStream fs2 = new FileInputStream( getPropertyFileForTesting( encoding, propMap ) );
+              InputStreamReader fr1 = new InputStreamReader( fs1, encoding );
+              InputStreamReader fr2 = new InputStreamReader( fs2, encoding ) )
         {
             Properties testPropertiesWithoutPrefix = new Properties();
-            testPropertiesWithoutPrefix.load( fs2 );
+            testPropertiesWithoutPrefix.load( fr2 );
 
             // do the work
             readPropertiesMojo.setKeyPrefix( keyPrefix );
-            readPropertiesMojo.setFiles( new File[] {getPropertyFileForTesting()} );
+            readPropertiesMojo.setFiles( new File[] {getPropertyFileForTesting( encoding, propMap )} );
             readPropertiesMojo.execute();
 
             // load properties directly and add prefix for comparison later
             Properties testPropertiesPrefix = new Properties();
-            testPropertiesPrefix.load( fs1 );
+            testPropertiesPrefix.load( fr1 );
 
             // check results
             Properties projectProperties = projectStub.getProperties();
@@ -87,34 +130,95 @@ public class ReadPropertiesMojoTest
             // properties with and without prefix shouldn't be same
             assertNotEquals( testPropertiesPrefix, testPropertiesWithoutPrefix );
             assertNotEquals( testPropertiesWithoutPrefix, projectProperties );
+
+            // strings which are representable in ISO-8859-1 should match the source data
+            for ( String sourceKey : ISO_8859_REPRESENTABLE.keySet() )
+            {
+                assertEquals( ISO_8859_REPRESENTABLE.get( sourceKey ), projectProperties.getProperty( keyPrefix + sourceKey ) );
+            }
+
+            // strings which are not representable in ISO-8859-1 underwent a conversion which lost data
+            for ( String sourceKey : ISO_8859_NOT_REPRESENTABLE.keySet() )
+            {
+                String sourceValue = ISO_8859_NOT_REPRESENTABLE.get( sourceKey );
+                String converted = new String( sourceValue.getBytes( encoding ), StandardCharsets.UTF_8 );
+                String propVal = projectProperties.getProperty( keyPrefix + sourceKey );
+                assertNotEquals( sourceValue, propVal );
+                assertEquals( converted, propVal );
+            }
         }
     }
 
-    private File getPropertyFileForTesting() throws IOException
+    @Test
+    public void readPropertiesWithEncoding() throws Exception
     {
-        return getPropertyFileForTesting( null );
+        final Map<String, String> propMap = new HashMap<>();
+        propMap.putAll( ISO_8859_REPRESENTABLE );
+        propMap.putAll( ISO_8859_NOT_REPRESENTABLE );
+
+        final String encoding = StandardCharsets.UTF_8.name();
+        File referenceFile = getPropertyFileForTesting( encoding, propMap );
+        try ( FileInputStream fileStream = new FileInputStream( referenceFile );
+              InputStreamReader fr = new InputStreamReader( fileStream, encoding ) )
+        {
+            // load properties directly for comparison later
+            Properties testProperties = new Properties();
+            testProperties.load( fr );
+
+            // do the work
+            readPropertiesMojo.setFiles( new File[] {getPropertyFileForTesting( encoding, propMap )} );
+            readPropertiesMojo.setEncoding( encoding );
+            readPropertiesMojo.execute();
+
+            // check results
+            Properties projectProperties = projectStub.getProperties();
+            assertNotNull( projectProperties );
+            // it should not be empty
+            assertNotEquals( 0, projectProperties.size() );
+
+            // we are not adding prefix, so properties should be same as in file
+            assertEquals( testProperties.size(), projectProperties.size() );
+            assertEquals( testProperties, projectProperties );
+
+            // all test values are representable in UTF-8 and should match original source data
+            for ( String sourceKey : propMap.keySet() )
+            {
+                assertEquals( propMap.get( sourceKey ), projectProperties.getProperty( sourceKey ) );
+            }
+        }
     }
 
-    private File getPropertyFileForTesting( String keyPrefix ) throws IOException
+    @Test
+    public void testInvalidEncoding() throws Exception
+    {
+        readPropertiesMojo.setFiles( new File[] {getPropertyFileForTesting( StandardCharsets.UTF_8.name(), ISO_8859_REPRESENTABLE )} );
+        readPropertiesMojo.setEncoding( "invalid-encoding" );
+        MojoExecutionException thrown = assertThrows( MojoExecutionException.class, () -> readPropertiesMojo.execute() );
+        assertEquals( thrown.getMessage(), "Invalid encoding 'invalid-encoding'" );
+    }
+
+    private File getPropertyFileForTesting( String encoding, Map<String, String> properties ) throws IOException
+    {
+        return getPropertyFileForTesting( null, encoding, properties );
+    }
+
+    private File getPropertyFileForTesting( String keyPrefix, String encoding, Map<String, String> properties ) throws IOException
     {
         File f = File.createTempFile( "prop-test", ".properties" );
         f.deleteOnExit();
-        FileWriter writer = new FileWriter( f );
-        String prefix = keyPrefix;
-        if ( prefix == null )
+        try (FileOutputStream fileStream = new FileOutputStream( f ); //
+             OutputStreamWriter writer = new OutputStreamWriter( fileStream, encoding ) )
         {
-            prefix = "";
-        }
-        try
-        {
-            writer.write( prefix + "test.property1=value1" + NEW_LINE );
-            writer.write( prefix + "test.property2=value2" + NEW_LINE );
-            writer.write( prefix + "test.property3=value3" + NEW_LINE );
+            String prefix = keyPrefix;
+            if ( prefix == null )
+            {
+                prefix = "";
+            }
+            for ( Map.Entry<String, String> entry : properties.entrySet() )
+            {
+                writer.write( prefix + entry.getKey() + "=" + entry.getValue() + NEW_LINE );
+            }
             writer.flush();
-        }
-        finally
-        {
-            writer.close();
         }
         return f;
     }

--- a/src/test/java/org/codehaus/mojo/properties/WriteProjectPropertiesMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/properties/WriteProjectPropertiesMojoTest.java
@@ -1,0 +1,141 @@
+package org.codehaus.mojo.properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.junit.Before;
+import org.junit.Test;
+
+public class WriteProjectPropertiesMojoTest
+{
+    private static final Map<String, String> ISO_8859_REPRESENTABLE = Map.of("test.property1", "value1®",
+                                                                             "test.property2", "value2");
+
+    private static final Map<String, String> ISO_8859_NOT_REPRESENTABLE = Map.of ("test.property3", "value3™",
+                                                                                  "test.property4", "κόσμε");
+
+    private MavenProject projectStub;
+    private WriteProjectProperties writePropertiesMojo;
+
+    @Before
+    public void setUp()
+    {
+        projectStub = new MavenProject();
+        writePropertiesMojo = new WriteProjectProperties();
+        writePropertiesMojo.setProject( projectStub );
+    }
+
+    @Test
+    public void writePropertiesDefaultEncoding() throws Exception
+    {
+        final Map<String, String> propMap = new HashMap<>();
+        propMap.putAll( ISO_8859_REPRESENTABLE );
+        propMap.putAll( ISO_8859_NOT_REPRESENTABLE );
+
+        final String encoding = AbstractWritePropertiesMojo.DEFAULT_ENCODING;
+
+        File outputFile = File.createTempFile( "prop-test", ".properties" );
+        outputFile.deleteOnExit();
+        writePropertiesMojo.setOutputFile( outputFile );
+
+        Properties projectProperties = projectStub.getProperties();
+        projectProperties.putAll( propMap );
+
+        writePropertiesMojo.execute();
+
+        try ( FileInputStream fileStream = new FileInputStream( outputFile );
+              InputStreamReader fr = new InputStreamReader( fileStream, encoding ) )
+        {
+            // load the properties we just saved
+            Properties savedProperties = new Properties();
+            savedProperties.load( fr );
+
+            // it should not be empty
+            assertNotEquals( 0, savedProperties.size() );
+
+            // we are not adding prefix, so properties should be same as in file
+            assertEquals( projectProperties.size(), savedProperties.size() );
+
+            // strings which are representable in ISO-8859-1 should match the source data
+            for ( String sourceKey : ISO_8859_REPRESENTABLE.keySet() )
+            {
+                assertEquals( ISO_8859_REPRESENTABLE.get( sourceKey ), savedProperties.getProperty( sourceKey ) );
+            }
+
+            // strings which are not representable in ISO-8859-1 underwent a conversion which lost data
+            for ( String sourceKey : ISO_8859_NOT_REPRESENTABLE.keySet() )
+            {
+                String sourceValue = ISO_8859_NOT_REPRESENTABLE.get( sourceKey );
+                String converted = new String( sourceValue.getBytes( encoding ), StandardCharsets.UTF_8 );
+                String propVal = savedProperties.getProperty( sourceKey );
+                assertNotEquals( sourceValue, propVal );
+                assertEquals( converted, propVal );
+            }
+        }
+    }
+
+    @Test
+    public void writePropertiesUTF8() throws Exception
+    {
+        final Map<String, String> propMap = new HashMap<>();
+        propMap.putAll( ISO_8859_REPRESENTABLE );
+        propMap.putAll( ISO_8859_NOT_REPRESENTABLE );
+
+        final String encoding = StandardCharsets.UTF_8.name();
+
+        File outputFile = File.createTempFile( "prop-test", ".properties" );
+        outputFile.deleteOnExit();
+        writePropertiesMojo.setOutputFile( outputFile );
+
+        Properties projectProperties = projectStub.getProperties();
+        projectProperties.putAll( propMap );
+
+        writePropertiesMojo.setEncoding( encoding );
+        writePropertiesMojo.execute();
+
+        try ( FileInputStream fileStream = new FileInputStream( outputFile );
+              InputStreamReader fr = new InputStreamReader( fileStream, encoding ) )
+        {
+            // load the properties we just saved
+            Properties savedProperties = new Properties();
+            savedProperties.load( fr );
+
+            // it should not be empty
+            assertNotEquals( 0, savedProperties.size() );
+
+            // we are not adding prefix, so properties should be same as in file
+            assertEquals( projectProperties.size(), savedProperties.size() );
+
+            // all test data is representable in UTF8, all should match source data
+            for ( String sourceKey : propMap.keySet() )
+            {
+                assertEquals( propMap.get( sourceKey ), savedProperties.getProperty( sourceKey ) );
+            }
+        }
+    }
+
+    @Test
+    public void testInvalidEncoding() throws Exception
+    {
+        final Map<String, String> propMap = new HashMap<>();
+        propMap.putAll(ISO_8859_REPRESENTABLE);
+
+        File outputFile = File.createTempFile( "prop-test", ".properties" );
+        outputFile.deleteOnExit();
+        writePropertiesMojo.setOutputFile( outputFile );
+        writePropertiesMojo.setEncoding( "invalid-encoding" );
+        MojoExecutionException thrown = assertThrows( MojoExecutionException.class, () -> writePropertiesMojo.execute() );
+        assertEquals( thrown.getMessage(), "Invalid encoding 'invalid-encoding'" );
+    }
+}


### PR DESCRIPTION
Issue #92

This adds an optional encoding parameter to the read-project-properties, write-project-properties, and write-active-profile-properties goals along with unit tests. It defaults to the original ISO-8859-1.