### PR TITLE
In WriteProjectProperties, replace a map.get+map.put by a map.computeIfPresent

### DIFF
--- a/src/main/java/org/codehaus/mojo/properties/WriteProjectProperties.java
+++ b/src/main/java/org/codehaus/mojo/properties/WriteProjectProperties.java
@@ -80,10 +80,7 @@ public class WriteProjectProperties extends AbstractWritePropertiesMojo {
         Enumeration<?> enumeration = systemProperties.keys();
         while (enumeration.hasMoreElements()) {
             String key = (String) enumeration.nextElement();
-            String value = systemProperties.getProperty(key);
-            if (projProperties.get(key) != null) {
-                projProperties.put(key, value);
-            }
+            projProperties.computeIfPresent(key, (k, v) -> systemProperties.getProperty(key));
         }
 
         Optional.ofNullable(excludedPropertyKeys)


### PR DESCRIPTION
In WriteProjectProperties, to allow system properties to over write key/value found in maven properties, a map.get+map.put is used.
Since Java 8, a simpler map.computeIfPresent could be used.
Fix issue #141 